### PR TITLE
Add condition to track increase in vested tokens

### DIFF
--- a/contracts/VestedToken.sol
+++ b/contracts/VestedToken.sol
@@ -110,6 +110,11 @@ contract VestedToken is Ownable {
                 unchecked {
                     emit Transfer(receiver, address(0), storedBalance - actualBalance);
                 }
+            } else {
+                _vestingBalances[vesting] = actualBalance;
+                unchecked {
+                    emit Transfer(address(0), receiver, actualBalance - storedBalance);
+                }
             }
         }
     }


### PR DESCRIPTION
An increase in vested tokens receivers balance (e.g. due to additional investing) is not contemplated by the current updateBalances function. This causes the updateAllBalances and updateBalances functions to fail in updating v1INCH balance and trigger the transfer event.